### PR TITLE
Add __dirname

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@
 
 var fs = require('fs');
 
-module.exports = fs.readFileSync('static/text.txt').toString();
+module.exports = fs.readFileSync(__dirname + 'static/text.txt').toString();


### PR DESCRIPTION
Stops `Error: ENOENT, no such file or directory 'static/text.txt'` error.
